### PR TITLE
Provide better defaults for the JVM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+test/Main.class
+test/test-standalone.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get -y update \
 
 WORKDIR /src
 
-RUN curl -s -O http://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz \
-    && tar -zxvf wgrib2.tgz \
+RUN curl -s -O http://www.ftp.cpc.ncep.noaa.gov/wd51we/wgrib2/wgrib2.tgz.v2.0.5 \
+    && tar -zxvf wgrib2.tgz.v2.0.5 \
     && cd grib2 \
     && make \
     && ln -s /src/grib2/wgrib2/wgrib2 /usr/local/bin/wgrib2

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,4 @@ RUN apt-get purge \
     && apt-get autoremove \
     && rm -rf /tmp/*
 
-COPY ./docker-run.sh /bin/
+COPY *.sh /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,3 +18,5 @@ RUN apt-get purge \
     && rm -rf /tmp/*
 
 COPY *.sh /bin/
+
+ENTRYPOINT ["/bin/docker-run.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+name = quay.io/farmlogs/clojure
+version = v2
+tag = $(name):$(version)
+
+all: test
+
+build:
+	docker build . -t $(tag)
+
+test/Main.class:
+	javac test/Main.java
+
+test/test-standalone.jar: test/Main.class
+	cd test && jar cfe test-standalone.jar Main Main.class
+
+build-test-image: build test/test-standalone.jar
+	docker build ./test -t farmlogs/clojure-test:test
+
+test: build-test-image
+	test/run-tests.sh
+
+push: test
+	docker push $(tag)
+
+clean:
+	rm -f test/Main.class test/test-standalone.jar

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-name = quay.io/farmlogs/clojure
-version = v2
+name = docker.farmlogsdev.com/clojure
+version = latest
 tag = $(name):$(version)
+
+.PHONY: all build build-test-image clean push test
 
 all: test
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,34 @@
 [![Docker Repository on Quay](https://quay.io/repository/farmlogs/clojure/status "Docker Repository on Quay")](https://quay.io/repository/farmlogs/clojure)
 
 Based off of the official Clojure docker image, but with `gdal-bin` tools and `docker-run.sh` (for providing command line JVM_OPTS) added.
+
+Example Dockerfile that uses this image:
+
+```
+FROM quay.io/farmlogs/clojure
+
+# Copy the project file first
+# This allows us to take advantage of caching for the
+# deps layer
+COPY ./project.clj /app/
+
+WORKDIR /app
+
+RUN lein deps
+
+# Copying the remaining files after the deps are fetched
+# means not having to fetch deps again until the project.clj
+# is changed
+COPY . .
+
+# Create an uberjar
+RUN ["/bin/bash", "-c", "lein uberjar && cp target/*-standalone.jar ./"]
+
+# optional, set any custom jvm options
+ENV JVM_OPTS="-Duser.timezone=UTC"
+
+# optional, override the default Xmx percentage (default is 50)
+ENV JVM_MAX_MEM_RATIO=75
+
+ENTRYPOINT ["/bin/docker-run.sh"]
+```

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ command line JVM_OPTS.
 
 ## Default options
 
-Since the JVM can't yet honor cgroups limits when in a container,
-`docker-run.sh` will add the following to the `JVM_OPTS` set by the
-child container:
+Since the JVM doesn't honor cgroups memory limits for calculating the
+default heap size when in a container, `docker-run.sh` will add the
+following to the `JVM_OPTS` set by the child container:
 
-* if `Xmx` (max heap size) isn't set and a memory resource limit is
-  applied to the container, it calculates an `Xmx` that is 50% of the
-  memory limit (the percentage can be overridden by setting
-  `JVM_MAX_MEM_RATIO`)
-* if a cpu/core resource limit is applied to the container, it sets
-  some properties that control the number of threads for GC, etc
+* if `Xmx` (max heap size) isn't set, it enables experimental heap
+  size calculation based on any cgroup memory limits. By default, it
+  will try to use close to 100% of the memory limit. You can Adjust
+  that by adding `-XX:MaxRAMFraction=n` to `JVM_OPTS`, where `n` is a
+  whole number used to divide the available memory by (so 1 = 100%, 2
+  = 50%, etc). Defaults to 1.
 * it adds an option that causes the JVM to kill itself if it runs out
   of memory
 * it adds properties to enable connecting to JMX remotely. This can be
@@ -52,9 +52,6 @@ RUN ["/bin/bash", "-c", "lein uberjar && cp target/*-standalone.jar ./"]
 
 # optional, set any custom jvm options
 ENV JVM_OPTS="-Duser.timezone=UTC"
-
-# optional, override the default Xmx percentage (default is 50)
-ENV JVM_MAX_MEM_RATIO=75
 
 # disable exposing JMX, it's exposed by default
 ENV JVM_EXPOSE_JMX=false

--- a/README.md
+++ b/README.md
@@ -2,9 +2,33 @@
 
 [![Docker Repository on Quay](https://quay.io/repository/farmlogs/clojure/status "Docker Repository on Quay")](https://quay.io/repository/farmlogs/clojure)
 
-Based off of the official Clojure docker image, but with `gdal-bin` tools and `docker-run.sh` (for providing command line JVM_OPTS) added.
+Based off of the official Clojure docker image, but with `gdal-bin`
+and `grib2` tools added, and a `docker-run.sh` script for providing
+command line JVM_OPTS.
 
-Example Dockerfile that uses this image:
+## Default options
+
+Since the JVM can't yet honor cgroups limits when in a container,
+`docker-run.sh` will add the following to the `JVM_OPTS` set by the
+child container:
+
+* if `Xmx` (max heap size) isn't set and a memory resource limit is
+  applied to the container, it calculates an `Xmx` that is 50% of the
+  memory limit (the percentage can be overridden by setting
+  `JVM_MAX_MEM_RATIO`)
+* if a cpu/core resource limit is applied to the container, it sets
+  some properties that control the number of threads for GC, etc
+* it adds an option that causes the JVM to kill itself if it runs out
+  of memory
+* it adds properties to enable connecting to JMX remotely. This can be
+  disabled by setting `JVM_EXPOSE_JMX` to `"false"`.
+  
+## Connecting to JMX in a container in kube
+
+1. `kubectl port-forward <pod name> 1099`
+2. `jconsole localhost:1099`
+
+## Example Dockerfile
 
 ```
 FROM quay.io/farmlogs/clojure
@@ -31,6 +55,9 @@ ENV JVM_OPTS="-Duser.timezone=UTC"
 
 # optional, override the default Xmx percentage (default is 50)
 ENV JVM_MAX_MEM_RATIO=75
+
+# disable exposing JMX, it's exposed by default
+ENV JVM_EXPOSE_JMX=false
 
 ENTRYPOINT ["/bin/docker-run.sh"]
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ following to the `JVM_OPTS` set by the child container:
 ## Example Dockerfile
 
 ```
-FROM quay.io/farmlogs/clojure
+FROM docker.farmlogsdev.com/clojure
 
 # Copy the project file first
 # This allows us to take advantage of caching for the
@@ -55,6 +55,9 @@ RUN ["/bin/bash", "-c", "lein uberjar && cp target/*-standalone.jar ./"]
 
 # optional, set any custom jvm options
 ENV JVM_OPTS="-Duser.timezone=UTC"
+
+# optional, specify the path to the jar (default will look for *-standalone.jar)
+ENV JAR_FILE="target/app.jar"
 
 # disable exposing JMX, it's exposed by default
 ENV JVM_EXPOSE_JMX=false

--- a/README.md
+++ b/README.md
@@ -59,5 +59,6 @@ ENV JVM_MAX_MEM_RATIO=75
 # disable exposing JMX, it's exposed by default
 ENV JVM_EXPOSE_JMX=false
 
-ENTRYPOINT ["/bin/docker-run.sh"]
+# optional, will be passed as args to the jvm process started by /bin/docker-run.sh
+CMD ["stuff" "and" "things"]
 ```

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Since the JVM doesn't honor cgroups memory limits for calculating the
 default heap size when in a container, `docker-run.sh` will add the
 following to the `JVM_OPTS` set by the child container:
 
-* if `Xmx` (max heap size) isn't set, it enables experimental heap
-  size calculation based on any cgroup memory limits. By default, it
+* if `Xmx` (max heap size) isn't set, it enables [experimental heap
+  size calculation][1] based on any cgroup memory limits. By default, it
   will try to use close to 100% of the memory limit. You can Adjust
   that by adding `-XX:MaxRAMFraction=n` to `JVM_OPTS`, where `n` is a
   whole number used to divide the available memory by (so 1 = 100%, 2
@@ -22,6 +22,9 @@ following to the `JVM_OPTS` set by the child container:
   of memory
 * it adds properties to enable connecting to JMX remotely. This can be
   disabled by setting `JVM_EXPOSE_JMX` to `"false"`.
+* it [disables eliding stack traces][2] for "fast throw" exceptions to
+  allow full stack traces to be reported to sentry. This can be
+  disabled by setting `JVM_FAST_THROW` to `"true"`.
   
 ## Connecting to JMX in a container in kube
 
@@ -59,3 +62,6 @@ ENV JVM_EXPOSE_JMX=false
 # optional, will be passed as args to the jvm process started by /bin/docker-run.sh
 CMD ["stuff" "and" "things"]
 ```
+
+[1]: https://dzone.com/articles/running-a-jvm-in-a-container-without-getting-kille
+[2]: https://stackoverflow.com/questions/4659151/recurring-exception-without-a-stack-trace-how-to-reset#4659279

--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ following to the `JVM_OPTS` set by the child container:
   = 50%, etc). Defaults to 1.
 * it adds an option that causes the JVM to kill itself if it runs out
   of memory
-* it adds properties to enable connecting to JMX remotely. This can be
-  disabled by setting `JVM_EXPOSE_JMX` to `"false"`.
+* it optionally adds properties to enable connecting to JMX
+  remotely. This can be enabled by setting `JVM_EXPOSE_JMX` to
+  `"true"`.
 * it [disables eliding stack traces][2] for "fast throw" exceptions to
   allow full stack traces to be reported to sentry. This can be
   disabled by setting `JVM_FAST_THROW` to `"true"`.
   
 ## Connecting to JMX in a container in kube
-
-1. `kubectl port-forward <pod name> 1099`
+  
+1. set `ENV JVM_EXPOSE_JMX=true` in your `Dockerfile` 
+2. `kubectl port-forward <pod name> 1099`
 2. `jconsole localhost:1099`
 
 ## Example Dockerfile
@@ -59,8 +61,8 @@ ENV JVM_OPTS="-Duser.timezone=UTC"
 # optional, specify the path to the jar (default will look for *-standalone.jar)
 ENV JAR_FILE="target/app.jar"
 
-# disable exposing JMX, it's exposed by default
-ENV JVM_EXPOSE_JMX=false
+# optional, expose JMX
+ENV JVM_EXPOSE_JMX=true
 
 # optional, will be passed as args to the jvm process started by /bin/docker-run.sh
 CMD ["stuff" "and" "things"]

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -11,6 +11,9 @@ if [ -z "${JVM_OPTS:-}" ]; then
   JVM_OPTS=""
 fi
 
+export JVM_OPTS
+JVM_OPTS="$(/bin/jvm-opts-with-defaults.sh)"
+
 JAVA=$(which java)
 
 cmd="${JAVA} ${JVM_OPTS} -jar $(ls *-standalone.jar) $*"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -11,12 +11,16 @@ if [ -z "${JVM_OPTS:-}" ]; then
   JVM_OPTS=""
 fi
 
+if [ -z "${JAR_FILE:-}" ]; then
+    JAR_FILE="$(ls *-standalone.jar)"
+fi
+
 export JVM_OPTS
 JVM_OPTS="$(/bin/jvm-opts-with-defaults.sh)"
 
 JAVA=$(which java)
 
-cmd="${JAVA} ${JVM_OPTS} -jar $(ls *-standalone.jar) $*"
+cmd="${JAVA} ${JVM_OPTS} -jar $JAR_FILE $*"
 
 if [ $DEBUG = true ]; then
   echo $cmd

--- a/jvm-opts-with-defaults.sh
+++ b/jvm-opts-with-defaults.sh
@@ -11,6 +11,8 @@
 #
 # JVM_OPTS: Checked for already set options
 # JVM_EXPOSE_JMX: if == 'false', jmx is not exposed
+# JVM_FAST_THROW: prevents adding the option that tells the JVM to keep
+#                 stack traces for "fast throw" exceptions
 
 opts_have() {
     echo "${JVM_OPTS}" | grep -q -- "$1"
@@ -63,5 +65,17 @@ expose_jmx() {
        "-Djava.rmi.server.hostname=127.0.0.1"
 }
 
+disable_fast_throw() {
+  if $(opts_have '-XX:-OmitStackTraceInFastThrow'); then
+    return
+  fi
+
+  if [ "x$JVM_FAST_THROW" = "xtrue" ]; then
+    return
+  fi
+
+  echo "-XX:-OmitStackTraceInFastThrow"
+}
+
 # Echo options, trimming trailing and multiple spaces
-echo "$(enable_cgroup_limits) $(max_ram_fraction) $(out_of_memory) $(expose_jmx) $JVM_OPTS" | awk '$1=$1'
+echo "$(enable_cgroup_limits) $(max_ram_fraction) $(out_of_memory) $(disable_fast_throw) $(expose_jmx) $JVM_OPTS" | awk '$1=$1'

--- a/jvm-opts-with-defaults.sh
+++ b/jvm-opts-with-defaults.sh
@@ -1,114 +1,45 @@
 #!/bin/sh
-
-# modified from https://github.com/fabric8io-images/java/blob/master/images/alpine/openjdk8/jdk/java-default-options
-# and https://github.com/fabric8io-images/java/blob/master/images/alpine/openjdk8/jdk/container-limits
-
-# =================================================================
-# Detect whether running in a container and set appropriate options
-# for limiting Java VM resources. Also include common tuning options,
-# and optionally enable GC diagnostics.
+#
+# Sets default options for the JVM, including:
+# * enabling cgroup memory limit detection and auto-generation of heap size
+# * exposing jmx via port localhost:1099
+# * setting the JVM to kill itself when it runs out of memory
 #
 # Usage: export JVM_OPTS; JVM_OPTS="$(jvm-opts-with-defaults.sh)"
-
-# Env Vars evaluated:
-
+#
+# Env vars evaluated:
+#
 # JVM_OPTS: Checked for already set options
-# JVM_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
-#                     E.g. the default value "50" implies that 50% of the Memory
-#                     given to the container is used as the maximum heap memory with
-#                     '-Xmx'. It is a heuristic and should be better backed up with real
-#                     experiments and measurements.
-#                     For a good overviews what tuning options are available -->
-#                             https://youtu.be/Vt4G-pHXfs4
-#                             https://www.youtube.com/watch?v=w1rZOY5gbvk
-#                             https://vimeo.com/album/4133413/video/181900266
-# Also note that heap is only a small portion of the memory used by a JVM. There are lot
-# of other memory areas (metadata, thread, code cache, ...) which addes to the overall
-# size. There is no easy solution for this, 50% seems to be are reasonable compromise.
-# However, when your container gets killed because of an OOM, then you should tune
-# the absolute values
-
-ceiling() {
-  awk -vnumber="$1" -vdiv="$2" '
-    function ceiling(x){
-      return x%1 ? int(x)+1 : x
-    }
-    BEGIN{
-      print ceiling(number/div)
-    }
-  '
-}
-
-# Based on the cgroup limits, figure out the max number of core we should utilize
-cgroups_core_limit() {
-  local cpu_period_file="/sys/fs/cgroup/cpu/cpu.cfs_period_us"
-  local cpu_quota_file="/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
-  if [ -r "${cpu_period_file}" ]; then
-    local cpu_period="$(cat ${cpu_period_file})"
-
-    if [ -r "${cpu_quota_file}" ]; then
-      local cpu_quota="$(cat ${cpu_quota_file})"
-      # cfs_quota_us == -1 --> no restrictions
-      if [ "x$cpu_quota" != "x-1" ]; then
-        ceiling "$cpu_quota" "$cpu_period"
-      fi
-    fi
-  fi
-}
-
-cgroups_max_memory() {
-  # High number which is the max limit unti which memory is supposed to be
-  # unbounded.
-  local max_mem_unbounded="$(cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes)"
-  local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
-  if [ -r "${mem_file}" ]; then
-    local max_mem="$(cat ${mem_file})"
-    if [ ${max_mem} -lt ${max_mem_unbounded} ]; then
-      echo "${max_mem}"
-    fi
-  fi
-}
+# JVM_EXPOSE_JMX: if == 'false', jmx is not exposed
 
 opts_have() {
-  if echo "${JVM_OPTS}" | grep -q -- "$1"; then
-    echo "true"
-  fi
+    echo "${JVM_OPTS}" | grep -q -- "$1"
+    return $?
 }
 
-# Check for memory options and calculate a sane default if not given
-max_memory() {
-  # Check whether -Xmx is already given in JVM_OPTS. Then we dont
-  # do anything here
-  if [ "$(opts_have '-Xmx')" = true ]; then
-    return
-  fi
-
-  # Check if explicitely disabled
-  if [ "x$JVM_MAX_MEM_RATIO" = "x0" ]; then
-    return
-  fi
-
-  # Check for the 'real memory size' and caluclate mx from a ratio
-  # given (default is 50%)
-  local max_mem="$(cgroups_max_memory)"
-  if [ "x$max_mem" != x ]; then
-    local ratio=${JVM_MAX_MEM_RATIO:-50}
-    local mx=$(echo "${max_mem} ${ratio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}')
-    echo "-Xmx${mx}m"
-  fi
+enable_cgroup_limits() {
+    if $(opts_have '-Xmx'); then
+        return
+    fi
+    
+    echo "-XX:+UnlockExperimentalVMOptions " \
+         "-XX:+UseCGroupMemoryLimitForHeap"
 }
 
-cpu_core_tunning() {
-  local core_limit="$(cgroups_core_limit)"
-  if [ "x$core_limit" != x ]; then
-    echo "-XX:ParallelGCThreads=${core_limit} " \
-         "-XX:ConcGCThreads=${core_limit} " \
-         "-Djava.util.concurrent.ForkJoinPool.common.parallelism=${core_limit}"
-  fi
+max_ram_fraction() {
+    if $(opts_have '-Xmx'); then
+        return
+    fi
+
+    if $(opts_have '-XX:MaxRAMFraction'); then
+        return
+    fi
+
+    echo "-XX:MaxRAMFraction=1"
 }
 
 out_of_memory() {
-  if echo "${JVM_OPTS}" | grep -q -- "-XX:OnOutOfMemoryError"; then
+  if $(opts_have '-XX:OnOutOfMemoryError'); then
     return
   fi
 
@@ -116,7 +47,7 @@ out_of_memory() {
 }
 
 expose_jmx() {
-  if [ "$(opts_have 'com.sun.management.jmx')" = true ]; then
+  if $(opts_have 'com.sun.management.jmx'); then
     return
   fi
 
@@ -133,4 +64,4 @@ expose_jmx() {
 }
 
 # Echo options, trimming trailing and multiple spaces
-echo "$(max_memory) $(cpu_core_tunning) $(out_of_memory) $(expose_jmx) $JVM_OPTS" | awk '$1=$1'
+echo "$(enable_cgroup_limits) $(max_ram_fraction) $(out_of_memory) $(expose_jmx) $JVM_OPTS" | awk '$1=$1'

--- a/jvm-opts-with-defaults.sh
+++ b/jvm-opts-with-defaults.sh
@@ -53,7 +53,7 @@ expose_jmx() {
     return
   fi
 
-  if [ "x$JVM_EXPOSE_JMX" = "xfalse" ]; then
+  if [ "x$JVM_EXPOSE_JMX" != "xtrue" ]; then
     return
   fi
     

--- a/jvm-opts-with-defaults.sh
+++ b/jvm-opts-with-defaults.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+
+# modified from https://github.com/fabric8io-images/java/blob/master/images/alpine/openjdk8/jdk/java-default-options
+# and https://github.com/fabric8io-images/java/blob/master/images/alpine/openjdk8/jdk/container-limits
+
+# =================================================================
+# Detect whether running in a container and set appropriate options
+# for limiting Java VM resources. Also include common tuning options,
+# and optionally enable GC diagnostics.
+#
+# Usage: export JVM_OPTS; JVM_OPTS="$(jvm-opts-with-defaults.sh)"
+
+# Env Vars evaluated:
+
+# JVM_OPTS: Checked for already set options
+# JVM_MAX_MEM_RATIO: Ratio use to calculate a default maximum Memory, in percent.
+#                     E.g. the default value "50" implies that 50% of the Memory
+#                     given to the container is used as the maximum heap memory with
+#                     '-Xmx'. It is a heuristic and should be better backed up with real
+#                     experiments and measurements.
+#                     For a good overviews what tuning options are available -->
+#                             https://youtu.be/Vt4G-pHXfs4
+#                             https://www.youtube.com/watch?v=w1rZOY5gbvk
+#                             https://vimeo.com/album/4133413/video/181900266
+# Also note that heap is only a small portion of the memory used by a JVM. There are lot
+# of other memory areas (metadata, thread, code cache, ...) which addes to the overall
+# size. There is no easy solution for this, 50% seems to be are reasonable compromise.
+# However, when your container gets killed because of an OOM, then you should tune
+# the absolute values
+
+ceiling() {
+  awk -vnumber="$1" -vdiv="$2" '
+    function ceiling(x){
+      return x%1 ? int(x)+1 : x
+    }
+    BEGIN{
+      print ceiling(number/div)
+    }
+  '
+}
+
+# Based on the cgroup limits, figure out the max number of core we should utilize
+cgroups_core_limit() {
+  local cpu_period_file="/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+  local cpu_quota_file="/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+  if [ -r "${cpu_period_file}" ]; then
+    local cpu_period="$(cat ${cpu_period_file})"
+
+    if [ -r "${cpu_quota_file}" ]; then
+      local cpu_quota="$(cat ${cpu_quota_file})"
+      # cfs_quota_us == -1 --> no restrictions
+      if [ "x$cpu_quota" != "x-1" ]; then
+        ceiling "$cpu_quota" "$cpu_period"
+      fi
+    fi
+  fi
+}
+
+cgroups_max_memory() {
+  # High number which is the max limit unti which memory is supposed to be
+  # unbounded. 
+  local max_mem_unbounded="$(cat /sys/fs/cgroup/memory/memory.memsw.limit_in_bytes)"
+  local mem_file="/sys/fs/cgroup/memory/memory.limit_in_bytes"
+  if [ -r "${mem_file}" ]; then
+    local max_mem="$(cat ${mem_file})"
+    if [ ${max_mem} -lt ${max_mem_unbounded} ]; then
+      echo "${max_mem}"
+    fi
+  fi
+}
+
+# Check for memory options and calculate a sane default if not given
+max_memory() {
+  # Check whether -Xmx is already given in JVM_OPTS. Then we dont
+  # do anything here
+  if echo "${JVM_OPTS}" | grep -q -- "-Xmx"; then
+    return
+  fi
+
+  # Check if explicitely disabled
+  if [ "x$JVM_MAX_MEM_RATIO" = "x0" ]; then
+    return
+  fi
+
+  # Check for the 'real memory size' and caluclate mx from a ratio
+  # given (default is 50%)
+  local max_mem="$(cgroups_max_memory)"
+  if [ "x$max_mem" != x ]; then
+    local ratio=${JVM_MAX_MEM_RATIO:-50}
+    local mx=$(echo "${max_mem} ${ratio} 1048576" | awk '{printf "%d\n" , ($1*$2)/(100*$3) + 0.5}')
+    echo "-Xmx${mx}m"
+  fi
+}
+
+cpu_core_tunning() {
+  local core_limit="$(cgroups_core_limit)"
+  if [ "x$core_limit" != x ]; then
+    echo "-XX:ParallelGCThreads=${core_limit} " \
+         "-XX:ConcGCThreads=${core_limit} " \
+         "-Djava.util.concurrent.ForkJoinPool.common.parallelism=${core_limit}"
+  fi
+}
+
+out_of_memory() {
+  if echo "${JVM_OPTS}" | grep -q -- "-XX:OnOutOfMemoryError"; then
+    return
+  fi
+
+  echo '"-XX:OnOutOfMemoryError=kill -9 %p"'
+}
+
+# Echo options, trimming trailing and multiple spaces
+echo "$(max_memory) $(cpu_core_tunning) $(out_of_memory) $JVM_OPTS" | awk '$1=$1'

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,4 @@
+FROM quay.io/farmlogs/clojure:v2
+
+COPY test-standalone.jar /src
+

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/farmlogs/clojure:v2
+FROM docker.farmlogsdev.com/clojure:latest
 
 COPY test-standalone.jar /src
 

--- a/test/Main.java
+++ b/test/Main.java
@@ -1,0 +1,5 @@
+public class Main {
+    public static void main(String[] args) {
+        System.out.println("success");
+    }
+}

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -56,6 +56,9 @@ has "$opts" '"-XX:OnOutOfMemoryError=kill -9 %p"'
 ## jmx
 has "$opts" '-Dcom.sun.management'
 
+## disable fast throw
+has "$opts" '-XX:-OmitStackTraceInFastThrow'
+
 # custom ram fraction
 opts="$(run '-e JVM_OPTS="-XX:MaxRAMFraction=2"')"
 has "$opts" '-XX:+UnlockExperimentalVMOptions'
@@ -78,6 +81,10 @@ missing "$opts" '"-XX:OnOutOfMemoryError=kill -9 %p"'
 # disable jmx
 opts="$(run '-e JVM_EXPOSE_JMX=false')"
 missing "$opts" '-Dcom.sun.management'
+
+# enabling fast throw
+opts="$(run '-e JVM_FAST_THROW=true')"
+missing "$opts" '-XX:-OmitStackTraceInFastThrow'
 
 # random option survives
 opts="$(run '-e JVM_OPTS=-Dwhatevs')"

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+run() {
+    echo "$(docker run -e DEBUG=true $1 farmlogs/clojure-test:test)"
+}
+
+assertions=0
+failures=0
+
+track() {
+    let assertions+=1
+    if [ "$1" -ne 0 ]; then
+        let failures+=1
+    fi
+}
+
+
+has() {
+    echo "$1" | grep -q -- "$2"
+    if [ "$?" -ne 0 ]; then
+        echo "Expected '$1' to contain '$2'"
+        track 1
+    else
+        track 0
+    fi
+}
+
+missing() {
+    echo "$1" | grep -q -- "$2"
+    if [ "$?" -eq 0 ] ; then
+        echo "Expected '$1' to not contain '$2'"
+        track 1
+    else
+        track 0
+    fi
+}
+
+results() {
+    echo "$assertions assertions, $failures failures"
+    
+    if [ "$failures" -gt 0 ]; then
+        exit $failures
+    fi
+}
+
+# defaults
+opts="$(run)"
+## memory/cgroup
+has "$opts" '-XX:+UnlockExperimentalVMOptions'
+has "$opts" '-XX:+UseCGroupMemoryLimitForHeap'
+has "$opts" '-XX:MaxRAMFraction=1'
+
+## oom
+has "$opts" '"-XX:OnOutOfMemoryError=kill -9 %p"'
+
+## jmx
+has "$opts" '-Dcom.sun.management'
+
+# custom ram fraction
+opts="$(run '-e JVM_OPTS="-XX:MaxRAMFraction=2"')"
+has "$opts" '-XX:+UnlockExperimentalVMOptions'
+has "$opts" '-XX:+UseCGroupMemoryLimitForHeap'
+has "$opts" '-XX:MaxRAMFraction=2'
+missing "$opts" '-XX:MaxRAMFraction=1'
+
+# custom Xmx
+opts="$(run '-e JVM_OPTS="-Xmx=1m"')"
+has "$opts" "-Xmx=1m"
+missing "$opts" '-XX:+UnlockExperimentalVMOptions'
+missing "$opts" '-XX:+UseCGroupMemoryLimitForHeap'
+missing "$opts" '-XX:MaxRAMFraction=1'
+
+# custom oom
+opts="$(run '-e JVM_OPTS="-XX:OnOutOfMemoryError=foo"')"
+has "$opts" '"-XX:OnOutOfMemoryError=foo"'
+missing "$opts" '"-XX:OnOutOfMemoryError=kill -9 %p"'
+
+# disable jmx
+opts="$(run '-e JVM_EXPOSE_JMX=false')"
+missing "$opts" '-Dcom.sun.management'
+
+# random option survives
+opts="$(run '-e JVM_OPTS=-Dwhatevs')"
+has "$opts" '-Dwhatevs'
+
+# confirm the default options don't prevent the JVM from starting
+out="$(docker run farmlogs/clojure-test:test)"
+if [ "$out" = "success" ]; then
+    track 0
+else
+    echo "FAIL: expected 'success', got '$out'"
+    track 1
+fi
+
+results

--- a/test/run-tests.sh
+++ b/test/run-tests.sh
@@ -53,9 +53,6 @@ has "$opts" '-XX:MaxRAMFraction=1'
 ## oom
 has "$opts" '"-XX:OnOutOfMemoryError=kill -9 %p"'
 
-## jmx
-has "$opts" '-Dcom.sun.management'
-
 ## disable fast throw
 has "$opts" '-XX:-OmitStackTraceInFastThrow'
 
@@ -78,9 +75,9 @@ opts="$(run '-e JVM_OPTS="-XX:OnOutOfMemoryError=foo"')"
 has "$opts" '"-XX:OnOutOfMemoryError=foo"'
 missing "$opts" '"-XX:OnOutOfMemoryError=kill -9 %p"'
 
-# disable jmx
-opts="$(run '-e JVM_EXPOSE_JMX=false')"
-missing "$opts" '-Dcom.sun.management'
+# enabling jmx
+opts="$(run '-e JVM_EXPOSE_JMX=true')"
+has "$opts" '-Dcom.sun.management'
 
 # enabling fast throw
 opts="$(run '-e JVM_FAST_THROW=true')"


### PR DESCRIPTION
This has quite a few changes, mostly geared around making JVM-based apps more robust and more easily debugged. An image based on this branch is available as `docker.farmlogsdev.com/clojure:latest`.